### PR TITLE
Address nits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,4 @@ cython_debug/
 .idea/
 
 # hydra output
-tests/outputs
+outputs/

--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "test", "dev"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:44796bb814a0913b9be2edaeef10f4e08b684c933e5cbf772be5df82cb871f54"
+content_hash = "sha256:110f4bbf9d21ee7b4ccbcf4cf2ca27266689f14426eb01ccae304b36141dbfc8"
 
 [[package]]
 name = "antlr4-python3-runtime"
@@ -159,6 +159,16 @@ summary = "brain-dead simple config-ini parsing"
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
+name = "isort"
+version = "5.12.0"
+requires_python = ">=3.8.0"
+summary = "A Python utility / library to sort Python imports."
+files = [
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default", "test", "dev"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:110f4bbf9d21ee7b4ccbcf4cf2ca27266689f14426eb01ccae304b36141dbfc8"
+content_hash = "sha256:5467a19f31f1faea931d1f9de2848e1471cd49f85e40e9c109c7f00a3a640de0"
 
 [[package]]
 name = "antlr4-python3-runtime"
@@ -319,6 +319,31 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+]
+
+[[package]]
+name = "ruff"
+version = "0.0.280"
+requires_python = ">=3.7"
+summary = "An extremely fast Python linter, written in Rust."
+files = [
+    {file = "ruff-0.0.280-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:48ed5aca381050a4e2f6d232db912d2e4e98e61648b513c350990c351125aaec"},
+    {file = "ruff-0.0.280-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:ef6ee3e429fd29d6a5ceed295809e376e6ece5b0f13c7e703efaf3d3bcb30b96"},
+    {file = "ruff-0.0.280-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d878370f7e9463ac40c253724229314ff6ebe4508cdb96cb536e1af4d5a9cd4f"},
+    {file = "ruff-0.0.280-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:83e8f372fa5627eeda5b83b5a9632d2f9c88fc6d78cead7e2a1f6fb05728d137"},
+    {file = "ruff-0.0.280-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7008fc6ca1df18b21fa98bdcfc711dad5f94d0fc3c11791f65e460c48ef27c82"},
+    {file = "ruff-0.0.280-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:fe7118c1eae3fda17ceb409629c7f3b5a22dffa7caf1f6796776936dca1fe653"},
+    {file = "ruff-0.0.280-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37359cd67d2af8e09110a546507c302cbea11c66a52d2a9b6d841d465f9962d4"},
+    {file = "ruff-0.0.280-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd58af46b0221efb95966f1f0f7576df711cb53e50d2fdb0e83c2f33360116a4"},
+    {file = "ruff-0.0.280-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e7c15828d09f90e97bea8feefcd2907e8c8ce3a1f959c99f9b4b3469679f33c"},
+    {file = "ruff-0.0.280-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2dae8f2d9c44c5c49af01733c2f7956f808db682a4193180dedb29dd718d7bbe"},
+    {file = "ruff-0.0.280-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5f972567163a20fb8c2d6afc60c2ea5ef8b68d69505760a8bd0377de8984b4f6"},
+    {file = "ruff-0.0.280-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8ffa7347ad11643f29de100977c055e47c988cd6d9f5f5ff83027600b11b9189"},
+    {file = "ruff-0.0.280-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7a37dab70114671d273f203268f6c3366c035fe0c8056614069e90a65e614bfc"},
+    {file = "ruff-0.0.280-py3-none-win32.whl", hash = "sha256:7784e3606352fcfb193f3cd22b2e2117c444cb879ef6609ec69deabd662b0763"},
+    {file = "ruff-0.0.280-py3-none-win_amd64.whl", hash = "sha256:4a7d52457b5dfcd3ab24b0b38eefaead8e2dca62b4fbf10de4cd0938cf20ce30"},
+    {file = "ruff-0.0.280-py3-none-win_arm64.whl", hash = "sha256:b7de5b8689575918e130e4384ed9f539ce91d067c0a332aedef6ca7188adac2d"},
+    {file = "ruff-0.0.280.tar.gz", hash = "sha256:581c43e4ac5e5a7117ad7da2120d960a4a99e68ec4021ec3cd47fe1cf78f8380"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 description = "Example code for managing structured, strongly-typed configuration in Hydra projects"
 requires-python = ">=3.10"
 readme = "README.md"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 authors = [
     {name = "Robert Fink", email = "robert.fink@helsing.ai"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "mypy>=1.4.1",
     "black>=23.7.0",
     "isort>=5.12.0",
+    "ruff>=0.0.280",
 ]
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,4 +21,8 @@ test = [
 dev = [
     "mypy>=1.4.1",
     "black>=23.7.0",
+    "isort>=5.12.0",
 ]
+
+[tool.isort]
+profile = "black"

--- a/src/hydra_config/decorator.py
+++ b/src/hydra_config/decorator.py
@@ -82,7 +82,7 @@ def hydra_main2(config_path: Path) -> Callable[[Callable[[Any], Any]], Any]:
 
         def decorated_main(_config: Any | None = None) -> Any:
             hydra_decorator = hydra.main(os.fspath(config_path), "config", "1.3")
-            return (hydra_decorator(hydra_main))()
+            return hydra_decorator(hydra_main)()
 
         return decorated_main
 

--- a/src/hydra_config/decorator.py
+++ b/src/hydra_config/decorator.py
@@ -69,11 +69,13 @@ def hydra_main2(config_path: Path) -> Callable[[Callable[[Any], Any]], Any]:
         @functools.wraps(task_function)
         def hydra_main(raw_config: Any) -> Any:
             # Converts the given DictConfig into a Config object with the type
-            # specified by the main method (ie, typically a project-defined `Config` class).
+            # specified by the main method (ie, typically a project-defined `Config`
+            # class).
             parameters = signature(task_function).parameters
             if parameters.get("config") is None:
                 raise Exception(
-                    "@hydra_main2 method must have first parameter of the form `config: Config`"
+                    "@hydra_main2 method must have first parameter "
+                    "of the form `config: Config`"
                 )
 
             config_class = parameters["config"].annotation

--- a/src/hydra_config/decorator.py
+++ b/src/hydra_config/decorator.py
@@ -34,13 +34,12 @@ class TokenConverter(Converter):
 
         if ctx.direction.is_serialize():
             return str(ctx.value)
-        elif ctx.direction.is_deserialize():
+        if ctx.direction.is_deserialize():
             if isinstance(ctx.value, str):
                 parts = ctx.value.split(":")
                 return Token(UUID(parts[0]), parts[1])
             raise NotImplementedError
-        else:
-            raise Exception("Invalid Context direction, this is a bug")
+        raise Exception("Invalid Context direction, this is a bug")
 
 
 class ConfigParser:

--- a/src/hydra_config/decorator.py
+++ b/src/hydra_config/decorator.py
@@ -8,10 +8,10 @@ from typing import Any
 from uuid import UUID
 
 import hydra
-from databind.core import Converter, Context, ObjectMapper
+from databind.core import Context, Converter, ObjectMapper
 from databind.json import JsonModule
 from omegaconf import DictConfig
-from typeapi import TypeHint, ClassTypeHint
+from typeapi import ClassTypeHint, TypeHint
 
 
 @dataclass(frozen=True)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Literal
 from uuid import UUID
 
-from hydra_config.decorator import hydra_main2, Token
+from hydra_config.decorator import Token, hydra_main2
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This addresses some nits (I didn't stack these as separate PRs because they're individually so small, but I can rebase and drop commits you don't want to merge):

- Update license metadata to match LICENSE text (LICENSE is Apache 2, but the default PDM metadata is MIT)
- Ignore Hydra outputs directory in the repository root (This is where the outputs directory is created when running `pdm run pytest tests` from the repository root, which I claim is more conventional than running from within the `tests` directory).
- Sort imports with isort
- Remove extra parens
- Lint with Ruff (Ruff is a very fast superset of flake8, implemented in Rust.)
- Remove `elif` after `return`